### PR TITLE
fix quad test after cheetah v0.7.3 update

### DIFF
--- a/gpsr/tests/test_modeling.py
+++ b/gpsr/tests/test_modeling.py
@@ -54,6 +54,7 @@ class TestModeling:
         screen.transfer_map = lambda x, y: torch.eye(7)
         screen.reading = torch.eye(3)
         screen.name = "test"
+        screen.length = torch.tensor(0.0)
 
         lattice = GPSRQuadScanLattice(l_quad, l_drift, screen)
 


### PR DESCRIPTION
Fixes the following issue:

`TestModeling.test_gpsr_quad_scan_lattice_track_and_observe` fails after cheetah v0.7.3 update due to tracking through a mock screen with zero length.