### PR TITLE
Allow different loss functions to be used in gpsr training

### DIFF
--- a/gpsr/train.py
+++ b/gpsr/train.py
@@ -13,7 +13,6 @@ from gpsr.modeling import GPSR
 
 
 class LitGPSR(L.LightningModule, ABC):
-
     def __init__(
         self, gpsr_model: GPSR, lr: float = 1e-3, loss_func: Callable = mae_loss
     ):


### PR DESCRIPTION
Add an argument to allow users to choose from different loss functions in the LitGPSR class, now it's default to mae_loss which should be backwards compatible with existing code