### PR TITLE
update python minimum version to 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     name: Test Suite
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     name: Test Suite
     steps:

--- a/environment.yml
+++ b/environment.yml
@@ -13,5 +13,5 @@ dependencies:
     - torch
     - lightning
     - tensorboard
-    - cheetah-accelerator>=0.7.2
+    - cheetah-accelerator>=0.8.0
     - zuko==1.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dynamic = [ "version" ]
 keywords = []
 name = "gpsr"
 readme = {file = "README.md", content-type = "text/markdown"}
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 dependencies = [
   "lightning>=2,<=2.6.1",
   "matplotlib>=3.3.0",
-  "cheetah-accelerator>=0.7.2",
+  "cheetah-accelerator>=0.8.0",
   "tensorboard",
   "scipy",
   "scikit-image",


### PR DESCRIPTION
Cheetah 0.8.0 now requires python>=3.11. This PR updates the python minimum version to 3.11 and Cheetah to version 0.8.0. 